### PR TITLE
Allow naming of Graphite metrics

### DIFF
--- a/src/graphite.js
+++ b/src/graphite.js
@@ -3,7 +3,8 @@ cubism_contextPrototype.graphite = function(host) {
   var source = {},
       context = this;
 
-  source.metric = function(expression) {
+  source.metric = function(expression, name) {
+    if (!name) name = expression + "";
     return context.metric(function(start, stop, step, callback) {
       d3.text(host + "/render?format=raw"
           + "&target=" + encodeURIComponent("alias(" + expression + ",'')")
@@ -12,7 +13,7 @@ cubism_contextPrototype.graphite = function(host) {
         if (!text) return callback(new Error("unable to load data"));
         callback(null, cubism_graphiteParse(text));
       });
-    }, expression += "");
+    }, name += "");
   };
 
   source.find = function(pattern, callback) {


### PR DESCRIPTION
When using Graphite we're not able to specify a name for the metric, which results in long metric names.

This patch should allow the following to work:

``` js
graphite.metric("myTarget", "name")
```

It will default the name of the metric to `expression` as before if the name parameter isn't given.

Let me know if I'm barking up the wrong tree. My JavaScript isn't fantastic.
