### PR TITLE
Keydown while holding Shift moves focus more than 1 unit

### DIFF
--- a/cubism.v1.js
+++ b/cubism.v1.js
@@ -22,7 +22,7 @@ cubism.context = function() {
       start1, stop1, // the start and stop for the next prepare event
       serverDelay = 5e3,
       clientDelay = 5e3,
-      shiftDiff = 20, // distance to move focus if shift is held
+      shiftDiff = 20, // default distance to move focus if shift is held
       event = d3.dispatch("prepare", "beforechange", "change", "focus"),
       scale = context.scale = d3.time.scale().range([0, size]),
       timeout,
@@ -66,6 +66,12 @@ cubism.context = function() {
     timeout = clearTimeout(timeout);
     return context;
   };
+
+  context.shiftDiff = function(diff) {
+    if (!arguments.length) shiftDiff = 20 // default
+    else shiftDiff = diff;
+    return update();
+  }
 
   timeout = setTimeout(context.start, 10);
 

--- a/src/context.js
+++ b/src/context.js
@@ -6,6 +6,7 @@ cubism.context = function() {
       start1, stop1, // the start and stop for the next prepare event
       serverDelay = 5e3,
       clientDelay = 5e3,
+      shiftDiff = 20, // default distance to move focus if shift is held
       event = d3.dispatch("prepare", "beforechange", "change", "focus"),
       scale = context.scale = d3.time.scale().range([0, size]),
       timeout,
@@ -49,6 +50,12 @@ cubism.context = function() {
     timeout = clearTimeout(timeout);
     return context;
   };
+
+  context.shiftDiff = function(diff) {
+    if (!arguments.length) shiftDiff = 20 // default
+    else shiftDiff = diff;
+    return update();
+  }
 
   timeout = setTimeout(context.start, 10);
 


### PR DESCRIPTION
Hey Mike/Square,

I was playing with cubism last night and wanted to be able to move more than 1 unit at a time, but didn't want to have to use the mouse. So, this PR allows users of cubism to hold shift while pressing the Left or Right arrow keys, and it will move the focus 20 units in the direction they'd like. 20 is an arbitrary number that seemed good to me, so there's no real significance behind that.

Anyways - I thought this would be useful. Have no idea if you wanted this kind of functionality or not.

Thanks for making awesome stuff!
