### PR TITLE
Fxed problems when setting style with IE9 when `i` is null on focus

### DIFF
--- a/src/rule.js
+++ b/src/rule.js
@@ -15,9 +15,10 @@ cubism_contextPrototype.rule = function() {
         .style("pointer-events", "none");
 
     context.on("focus.rule-" + id, function(i) {
-      line
-          .style("display", i == null ? "none" : null)
-          .style("left", function() { return this.parentNode.getBoundingClientRect().left + i + "px"; });
+        line.style("display", i == null ? "none" : null);
+        if (i != null) {
+            line.style("left", function() { return this.parentNode.getBoundingClientRect().left + i + "px"; });
+        }
     });
   }
 


### PR DESCRIPTION
IE9 croak in case of an invalid CSS attribute value. In this case, if `i` is null, the value for `left` is tried to set to `NaNpx` which most browsers tolerate, but not IE9. 

I still didn't get IE9 to work with cubism.js, though. However, at least the ruler works ;-] (I'm still investigating it further)
