### PR TITLE
While dragging the rule the value disappears

### DIFF
--- a/src/metric.js
+++ b/src/metric.js
@@ -81,7 +81,7 @@ cubism_contextPrototype.metric = function(request, name) {
 
   //
   metric.valueAt = function(i) {
-    return values[i];
+    return values[Math.round(i)];
   };
 
   //


### PR DESCRIPTION
This is because valueAt() receives a float value and uses it as the index to an array.

Rounding fixed the issue for me.
