### PR TITLE
Graphite summarize function fix

### DIFF
--- a/cubism.v1.js
+++ b/cubism.v1.js
@@ -198,7 +198,7 @@ cubism_contextPrototype.graphite = function(host) {
 
       // Apply the summarize, if necessary.
       if (step !== 1e4) target = "summarize(" + target + ",'"
-          + (!(step % 36e5) ? step / 36e5 + "hour" : !(step % 6e4) ? step / 6e4 + "min" : step / 1e3 + "sec")
+          + (!(step % 36e5) ? step / 36e5 + "hour" : !(step % 6e4) ? step / 6e4 + "min" : step + "sec")
           + "','" + sum + "')";
 
       d3.text(host + "/render?format=raw"

--- a/src/graphite.js
+++ b/src/graphite.js
@@ -11,7 +11,7 @@ cubism_contextPrototype.graphite = function(host) {
 
       // Apply the summarize, if necessary.
       if (step !== 1e4) target = "summarize(" + target + ",'"
-          + (!(step % 36e5) ? step / 36e5 + "hour" : !(step % 6e4) ? step / 6e4 + "min" : step + "sec")
+          + (!(step % 36e5) ? step / 36e5 + "hour" : !(step % 6e4) ? step / 6e4 + "min" : step / 1e3 + "sec")
           + "','" + sum + "')";
 
       d3.text(host + "/render?format=raw"


### PR DESCRIPTION
The context.step is defined in milliseconds. But there is no step to convert between milliseconds and seconds before sending data to graphite. Currently metrics that have to be summarized in seconds are broken as the request is sent to graphite in milliseconds. 

Configuration:
var context = cubism.context()
    .step(15 \* 1000) // 15 seconds per value
    .size(1440); // fetch 1440 values

Result:
http://carbon1/render?format=raw&target=alias(summarize(my_stat, '15000sec', 'sum'),'')&from=1342097670&until=1342119299
