### PR TITLE
Add Support For Ganglia Metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ cubism.v1.js: \
 	src/context.js \
 	src/cube.js \
 	src/graphite.js \
+	src/gangliaWeb.js \
 	src/metric.js \
 	src/metric-constant.js \
 	src/metric-operator.js \

--- a/src/gangliaWeb.js
+++ b/src/gangliaWeb.js
@@ -1,0 +1,93 @@
+cubism_contextPrototype.gangliaWeb = function(config) {
+  var host = '',
+      uriPathPrefix = '/ganglia2/';
+ 
+  if (arguments.length) {
+    if (config.host) {
+      host = config.host;
+    }
+
+    if (config.uriPathPrefix) {
+      uriPathPrefix = config.uriPathPrefix;
+
+      /* Add leading and trailing slashes, as appropriate. */
+      if( uriPathPrefix[0] != '/' ) {
+        uriPathPrefix = '/' + uriPathPrefix;
+      }
+
+      if( uriPathPrefix[uriPathPrefix.length - 1] != '/' ) {
+        uriPathPrefix += '/';
+      }
+    }
+  }
+
+  var source = {},
+      context = this;
+
+  source.metric = function(metricInfo) {
+
+    /* Store the members from metricInfo into local variables. */
+    var clusterName = metricInfo.clusterName, 
+        metricName = metricInfo.metricName, 
+        hostName = metricInfo.hostName,
+        isReport = metricInfo.isReport || false,
+        titleGenerator = metricInfo.titleGenerator ||
+          /* Reasonable (not necessarily pretty) default for titleGenerator. */
+          function(unusedMetricInfo) {
+            /* unusedMetricInfo is, well, unused in this default case. */
+            return ('clusterName:' + clusterName + 
+                    ' metricName:' + metricName +
+                    (hostName ? ' hostName:' + hostName : ''));
+          },
+        onChangeCallback = metricInfo.onChangeCallback;
+    
+    /* Default to plain, simple metrics. */
+    var metricKeyName = isReport ? 'g' : 'm';
+
+    var gangliaWebMetric = context.metric(function(start, stop, step, callback) {
+
+      function constructGangliaWebRequestQueryParams() {
+        return ('c=' + clusterName +
+                '&' + metricKeyName + '=' + metricName + 
+                (hostName ? '&h=' + hostName : '') + 
+                '&cs=' + start/1000 + '&ce=' + stop/1000 + '&step=' + step/1000 + '&graphlot=1');
+      }
+
+      d3.json(host + uriPathPrefix + 'graph.php?' + constructGangliaWebRequestQueryParams(),
+        function(result) {
+          if( !result ) {
+            return callback(new Error("Unable to fetch GangliaWeb data"));
+          }
+
+          callback(null, result[0].data);
+        });
+
+    }, titleGenerator(metricInfo));
+
+    gangliaWebMetric.toString = function() {
+      return titleGenerator(metricInfo);
+    };
+
+    /* Allow users to run their custom code each time a gangliaWebMetric changes.
+     *
+     * TODO Consider abstracting away the naked Cubism call, and instead exposing 
+     * a callback that takes in the values array (maybe alongwith the original
+     * start and stop 'naked' parameters), since it's handy to have the entire
+     * dataset at your disposal (and users will likely implement onChangeCallback
+     * primarily to get at this dataset).
+     */
+    if (onChangeCallback) {
+      gangliaWebMetric.on('change', onChangeCallback);
+    }
+
+    return gangliaWebMetric;
+  };
+
+  // Returns the gangliaWeb host + uriPathPrefix.
+  source.toString = function() {
+    return host + uriPathPrefix;
+  };
+
+  return source;
+};
+


### PR DESCRIPTION
Apache Ambari (http://incubator.apache.org/ambari/index.html) uses Ganglia (with RRDs, not Graphite) for its metrics, and we were very interested in upgrading to using your fantastic Cubism visualization for said metrics across all the hosts in a Ganglia cluster.

I wrote the new gangliaWeb.js Cubism source (and have it working nicely), so I figured I'd give back to the community - feedback would be much appreciated, and I'll be happy to make improvements as you might see fit.

Using GangliaWeb as a source means users of Ganglia get to work with both RRDs and Graphite as the storage engine, for the price of one.

Thanks for the great foundation, Mike!

/V

P.S. Prospective early adopters should note that this won't work with GangliaWeb until https://github.com/ganglia/ganglia-web/pull/110 is committed.
