### PR TITLE
Fixes 2 bugs under FireFox 3.6

### DIFF
--- a/cubism.v1.js
+++ b/cubism.v1.js
@@ -1,6 +1,13 @@
 (function(exports){
 var cubism = exports.cubism = {version: "1.2.2"};
 var cubism_id = 0;
+if (typeof Object.create === 'undefined') {
+  Object.create = function (o) {
+    function F() {};
+    F.prototype = o;
+    return new F();
+  };
+}
 function cubism_identity(d) { return d; }
 cubism.option = function(name, defaultValue) {
   var values = cubism.options(name);
@@ -547,6 +554,7 @@ cubism_contextPrototype.horizon = function() {
           for (var i = i0, n = width, y1; i < n; ++i) {
             y1 = metric_.valueAt(i);
             if (y1 <= 0) { negative = true; continue; }
+            if (typeof y1 =="undefined") { continue; }
             canvas.fillRect(i, y1 = scale(y1), 1, y0 - y1);
           }
         }


### PR DESCRIPTION
I know, I know, FireFox 3.6.  Turns out, some of our developers still use
FF 3.6 to support users that may be on older browsers.  That is, they don't
want to push code that is broken for these users.  This commit should fix
problems with cubeism and FireFox 3.6.  Note: author will need to minify.

First, FireFox 3.6 does not support full ECMA5, which means Object.create()
needed to be stubbed out if it was undefined.

Second, canvas.fillRect() is less forgiving on FF 3.6.  If y1 comes in
undefined, then we should not pass it, or operations based on it, to
fillRect().

This fix tested in latest Safari (MAC), latest FireFox, FireFox 3.6,
and latest Chrome.
