### PR TITLE
Add keepLastValue(): basic graphite interpolation

### DIFF
--- a/src/graphite.js
+++ b/src/graphite.js
@@ -4,7 +4,8 @@ cubism_contextPrototype.graphite = function(host) {
       context = this;
 
   source.metric = function(expression) {
-    var sum = "sum";
+    var sum = "sum",
+        keepLastValue = false;
 
     var metric = context.metric(function(start, stop, step, callback) {
       var target = expression;
@@ -13,6 +14,8 @@ cubism_contextPrototype.graphite = function(host) {
       if (step !== 1e4) target = "summarize(" + target + ",'"
           + (!(step % 36e5) ? step / 36e5 + "hour" : !(step % 6e4) ? step / 6e4 + "min" : step / 1e3 + "sec")
           + "','" + sum + "')";
+
+      if (keepLastValue) target = "keepLastValue(" + target + ")";
 
       d3.text(host + "/render?format=raw"
           + "&target=" + encodeURIComponent("alias(" + target + ",'')")
@@ -25,6 +28,11 @@ cubism_contextPrototype.graphite = function(host) {
 
     metric.summarize = function(_) {
       sum = _;
+      return metric;
+    };
+
+    metric.keepLastValue = function () {
+      keepLastValue = true;
       return metric;
     };
 


### PR DESCRIPTION
This commit adds a "keepLastValue()" method to graphite metric objects, 
allowing metrics with resolutions less than the step size to be displayed as 
continuous blocks of colour, rather than "delta comb"-style plots.

I've added this here, because it provides a consistent way to call graphite's
`keepLastValue` function when the cubism step size isn't the default. The
problem is that you want to call `keepLastValue` on the output of `summarize`,
which `context.graphite` doesn't (as far as I can tell) currently provide any
facility to do.

Do let me know if you'd rather it be called something else, or if you'd like
me to include the recompiled cubism.v1.js in the branch, etc!