### PR TITLE
Add .hideEmpty(true) feature

### DIFF
--- a/cubism.v1.js
+++ b/cubism.v1.js
@@ -252,7 +252,8 @@ function cubism_graphiteParse(text) {
       .substring(i + 1)
       .split(",")
       .slice(1) // the first value is always None?
-      .map(function(d) { return +d; });
+      .map(function(d) { return +d; })
+      .filter(Boolean); // Remove any NaN and return and empty array
 }
 cubism_contextPrototype.gangliaWeb = function(config) {
   var host = '',
@@ -434,6 +435,11 @@ cubism_contextPrototype.metric = function(request, name) {
   };
 
   //
+  metric.valueAll = function() {
+    return values;
+  };
+
+  //
   metric.shift = function(offset) {
     return context.metric(cubism_metricShift(request, +offset));
   };
@@ -558,7 +564,8 @@ cubism_contextPrototype.horizon = function() {
       extent = null,
       title = cubism_identity,
       format = d3.format(".2s"),
-      colors = ["#08519c","#3182bd","#6baed6","#bdd7e7","#bae4b3","#74c476","#31a354","#006d2c"];
+      colors = ["#08519c","#3182bd","#6baed6","#bdd7e7","#bae4b3","#74c476","#31a354","#006d2c"],
+      hideEmpty = false;
 
   function horizon(selection) {
 
@@ -687,6 +694,16 @@ cubism_contextPrototype.horizon = function() {
       // Note that someone still needs to listen to the metric,
       // so that it continues to update automatically.
       metric_.on("change.horizon-" + id, function(start, stop) {
+
+        // Hide graphs if the retrieved data set is empty
+        if (hideEmpty) {
+          if (d.valueAll().length == 0) {
+            selection.style("display", "none");
+          } else {
+            selection.style("display", "block");
+          }
+        }
+
         change(start, stop), focus();
         if (ready) metric_.on("change.horizon-" + id, cubism_identity);
       });
@@ -758,6 +775,12 @@ cubism_contextPrototype.horizon = function() {
   horizon.colors = function(_) {
     if (!arguments.length) return colors;
     colors = _;
+    return horizon;
+  };
+
+  horizon.hideEmpty = function(_) {
+    if (!arguments.length) return hideEmpty;
+    hideEmpty = _;
     return horizon;
   };
 

--- a/src/graphite.js
+++ b/src/graphite.js
@@ -65,5 +65,6 @@ function cubism_graphiteParse(text) {
       .substring(i + 1)
       .split(",")
       .slice(1) // the first value is always None?
-      .map(function(d) { return +d; });
+      .map(function(d) { return +d; })
+      .filter(Boolean); // Remove any NaN and return and empty array
 }

--- a/src/horizon.js
+++ b/src/horizon.js
@@ -9,7 +9,8 @@ cubism_contextPrototype.horizon = function() {
       extent = null,
       title = cubism_identity,
       format = d3.format(".2s"),
-      colors = ["#08519c","#3182bd","#6baed6","#bdd7e7","#bae4b3","#74c476","#31a354","#006d2c"];
+      colors = ["#08519c","#3182bd","#6baed6","#bdd7e7","#bae4b3","#74c476","#31a354","#006d2c"],
+      hideEmpty = false;
 
   function horizon(selection) {
 
@@ -138,6 +139,16 @@ cubism_contextPrototype.horizon = function() {
       // Note that someone still needs to listen to the metric,
       // so that it continues to update automatically.
       metric_.on("change.horizon-" + id, function(start, stop) {
+
+        // Hide graphs if the retrieved data set is empty
+        if (hideEmpty) {
+          if (d.valueAll().length == 0) {
+            selection.style("display", "none");
+          } else {
+            selection.style("display", "block");
+          }
+        }
+
         change(start, stop), focus();
         if (ready) metric_.on("change.horizon-" + id, cubism_identity);
       });
@@ -209,6 +220,12 @@ cubism_contextPrototype.horizon = function() {
   horizon.colors = function(_) {
     if (!arguments.length) return colors;
     colors = _;
+    return horizon;
+  };
+
+  horizon.hideEmpty = function(_) {
+    if (!arguments.length) return hideEmpty;
+    hideEmpty = _;
     return horizon;
   };
 

--- a/src/metric.js
+++ b/src/metric.js
@@ -85,6 +85,11 @@ cubism_contextPrototype.metric = function(request, name) {
   };
 
   //
+  metric.valueAll = function() {
+    return values;
+  };
+
+  //
   metric.shift = function(offset) {
     return context.metric(cubism_metricShift(request, +offset));
   };


### PR DESCRIPTION
After having the necessity of filtering the graphs that had an empty dataset, I came up with this feature. 

http://stackoverflow.com/questions/17374540/do-not-draw-empty-metrics
