### PR TITLE
Improve librato source

### DIFF
--- a/src/librato.js
+++ b/src/librato.js
@@ -5,19 +5,7 @@ cubism_contextPrototype.librato = function(user, token) {
   var source      = {},
       context     = this;
       auth_string = "Basic " + btoa(user + ":" + token);
-      enable_log  = false,
       avail_rsts  = [ 1, 60, 900, 3600 ];
-
-  function log(msg) { if (enable_log) console.log(msg); }
-
-  function log_interval(start, stop, step) {
-    log("---------------------- Starting request");
-    log("START: " + new Date(start * 1000));
-    log("STOP : " + new Date(stop * 1000));
-    log("STEP : " + step);
-    var nes_num_mes = (stop - start)/step;
-    log("# of measurements necessary: " + nes_num_mes);
-  }
 
   /* Given a step, find the best librato resolution to use.
    *
@@ -100,11 +88,7 @@ cubism_contextPrototype.librato = function(user, token) {
                       "&start_time=" + sdate     +
                       "&end_time="   + edate     +
                       "&resolution=" + find_librato_resolution(sdate, edate, step);
-          full_url  = url_prefix + "?" + params;
-
-      log("full_url = " + full_url);
-      log_interval(sdate, edate, step);
-      return full_url;
+      return url_prefix + "?" + params;
     }
 
     /*
@@ -150,7 +134,6 @@ cubism_contextPrototype.librato = function(user, token) {
           .header("Librato-User-Agent", 'cubism/' + cubism.version)
           .get(function (error, data) { /* Callback; data available */
             if (!error) {
-              log("# of partial measurements: " + data.measurements[0].length);
               if (data.measurements.length === 0) {
                 return
               }
@@ -158,17 +141,11 @@ cubism_contextPrototype.librato = function(user, token) {
 
               var still_more_values = 'query' in data && 'next_time' in data.query;
               if (still_more_values) {
-                log("Requesting more values");
                 actual_request(make_url(data.query.next_time, iedate, step));
               } else {
-                log("total number of measurements from librato: " + a_values.length);
                 var a_adjusted = down_up_sampling(isdate, iedate, step, a_values);
-                log("number of measurements after adjusting time values: " + a_adjusted.length);
                 callback_done(a_adjusted);
               }
-            } else {
-              log("There was an error when performing the librato request:");
-              log(error);
             }
           });
       }


### PR DESCRIPTION
The current librato source retrieve all data from a metric, and then filter by source, but if you have many sources this will be very slow and inefficient.

This use [librato composite metric feature](http://support.metrics.librato.com/knowledgebase/articles/337431-composite-metrics-language-specification) to be able to do retrieve a metrics/sources in one call, so this will make librato API look like this:

``` javascript
var context = cubism.context(), // a default context
    librato = context.librato("foo@gmail.com", "8585ae5c30d55ddef4");

var metrics = librato.metric("sum(series(\"hgsc_cpu_used\",  \"ardmore\"))");
```
