### PR TITLE
draw new data after a context has been stopped and then started

### DIFF
--- a/src/horizon.js
+++ b/src/horizon.js
@@ -57,8 +57,8 @@ cubism_contextPrototype.horizon = function() {
         var i0 = 0, max = Math.max(-extent[0], extent[1]);
         if (this === context) {
           if (max == max_) {
-            i0 = width - cubism_metricOverlap;
             var dx = (start1 - start) / step;
+            i0 = width - dx - cubism_metricOverlap;
             if (dx < width) {
               var canvas0 = buffer.getContext("2d");
               canvas0.clearRect(0, 0, width, height);


### PR DESCRIPTION
This fixes issue #74.

I'm not quite sure why `cubism_metricOverlap` is subtracted, so I left it there.

I tested it with just 

``` javascript
i0 = width -dx
```

and it seemed to work ok, except I once saw a single unfilled vertical pixel line, so maybe it's best to at least have 

``` javascript
i0 = width - dx - 1
```
