### PR TITLE
New find method "find_from_metrics". 

### DIFF
--- a/cubism.v1.js
+++ b/cubism.v1.js
@@ -411,6 +411,15 @@ cubism_contextPrototype.graphite = function(host) {
     });
   };
 
+  source.find_from_metrics = function(pattern, callback) {
+    d3.json(host + "/render?format=json\&from=-5min"
+        + "&target=" + encodeURIComponent(pattern), function(result) {
+      if (!result) return callback(new Error("unable to find metrics"));
+      callback(null, result.map(function(d) { return d.target; }));
+    });
+  };
+
+
   // Returns the graphite host.
   source.toString = function() {
     return host;


### PR DESCRIPTION
This makes it possible to find metrics based on graphite calculations. This is not possible through  the "/find" endpoint and "graphite.metric" expects one specific time series metric. The following example will return the 50 highest ICMP RTT times towards a central server (collected by collectd):

``` javascript
var graph_regex = "highestCurrent(collectd.*.ping.icmp-beacon_example_com,50)";

graphite.find_from_metrics(graph_regex, function(error, results) {
   metrics = results.sort().map(function(i) {
       var s = i.split(".");
       return graphite.metric(i)
              .alias(s[1])
              .summarize("avg");
   });
   for (var i=0;i<metrics.length;i++) { 
     d3.select("#graphs").call(function(div) {
     div.append("div").selectAll(".horizon")
        .data([metrics[i]])
       .enter().append("div")
       .attr("class", "horizon")
       .call(context.horizon());
     });
   };
});
```
